### PR TITLE
fix: ts 7016

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "module": "./dist/pinia-persist-uni.es.js",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/pinia-persist-uni.es.js",
       "require": "./dist/pinia-persist-uni.umd.js"
     }


### PR DESCRIPTION
```text
import piniaPersist from 'pinia-plugin-persist-uni';
Could not find a declaration file for module 'pinia-plugin-persist-uni'. 'node_modules/pinia-plugin-persist-uni/dist/pinia-persist-uni.es.js' implicitly has an 'any' type.
  There are types at 'node_modules/pinia-plugin-persist-uni/dist/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'pinia-plugin-persist-uni' library may need to update its package.json or typings.
ts(7016)
```